### PR TITLE
Require receipt of "content"

### DIFF
--- a/components/NOT.md
+++ b/components/NOT.md
@@ -2,9 +2,7 @@
     that everyone who receives
     a copy of the software
     from you
-    also receives copies,
-    or free-of-charge access to copies,
-    of
+    also receives the content of
     this license,
     any licensing notices,
     and any notices about how to get source code.


### PR DESCRIPTION
@jashkenas, this doesn't feel _good enough_, but it's a stab at the issue with "free-of-charge access to copies" that you brought up in a gist.

The key to keeping language like this short is usually to boil objectives down to their essence, and address them directly. With notices, I think the point is that contributors put notice and license terms in their software to communicate to their users, and users shouldn't break that chain of communication.